### PR TITLE
fix(joi-router): incorrect assertion parameters order

### DIFF
--- a/joi-router.js
+++ b/joi-router.js
@@ -274,7 +274,7 @@ function checkPreHandler(spec) {
  */
 
 function isSupportedFunction(handler) {
-  assert.strictEqual('function', typeof handler, 'route handler must be a function');
+  assert.strictEqual(typeof handler, 'function', 'route handler must be a function');
 
   if (isGenFn(handler)) {
     throw new Error(`route handlers must not be GeneratorFunctions


### PR DESCRIPTION
I found that the order of deepEqual assertion params is not in a correct order.

Here is the reference from official nodejs document.

https://nodejs.org/dist/v16.20.2/docs/api/assert.html#assertdeepequalactual-expected-message